### PR TITLE
Fix: Not to escape `GravityForm` blade output

### DIFF
--- a/src/Modules/GravityForm/includes/frontend.blade.php
+++ b/src/Modules/GravityForm/includes/frontend.blade.php
@@ -1,3 +1,3 @@
 @if(!empty($settings->form_id))
-    {{ gravity_form(absint($settings->form_id), $settings->show_title, $settings->show_descr, false, null, $settings->enable_ajax, $settings->tab_index, false) }}
+    {!! gravity_form(absint($settings->form_id), $settings->show_title, $settings->show_descr, false, null, $settings->enable_ajax, $settings->tab_index, false) !!}
 @endif


### PR DESCRIPTION
https://discourse.roots.io/t/blade-print-with-escape-syntax/9868