### PR TITLE
Add getter and setter for initializables. Setter is more convienient …

### DIFF
--- a/src/SageFLBuilder.php
+++ b/src/SageFLBuilder.php
@@ -87,6 +87,18 @@ final class SageFLBuilder
         return $this;
     }
 
+    public function getInitializables()
+    {
+        return $this->initializables;
+    }
+
+    public function setInitializables($initializables): self
+    {
+        $this->initializables = $initializables;
+
+        return $this;
+    }
+
     public function init(): void
     {
         sage()->instance(AbstractHelper::class, $this->helper);


### PR DESCRIPTION
…way to disable all default initializables.

This way we don't have explicitly say we want to remove BB Module within initializables.
Remove method required us to explicitly remove each BB module and use full namespace of the module, moreover - initializables was private property, so without any review of the sage-flbuilder code there was no power of modyfing those.